### PR TITLE
Updates to work with recent kernels (including 5.12.x)  (and other fixes)

### DIFF
--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -1313,7 +1313,7 @@ int ch341_gpio_get_multiple (struct gpio_chip *chip,
             *bits |= (((ch341_dev->gpio_io_data & ch341_dev->gpio_bits[i]) ? 1 : 0) << i);
         }
 
-    DEV_DBG (CH341_IF_ADDR, "mask=%08lx bit=0x%08lx io_data=0x%08x", *mask, *bits, ch341_dev->gpio_io_data);
+    // DEV_DBG (CH341_IF_ADDR, "mask=%08lx bit=0x%08lx io_data=0x%08x", *mask, *bits, ch341_dev->gpio_io_data);
 
     return CH341_OK;
 }
@@ -1371,7 +1371,7 @@ void ch341_gpio_set_multiple (struct gpio_chip *chip,
         }
     }
         
-    DEV_DBG (CH341_IF_ADDR, "mask=%08lx bit=%08lx io_data=0x%08x", *mask, *bits, ch341_dev->gpio_io_data);
+    // DEV_DBG (CH341_IF_ADDR, "mask=%08lx bit=%08lx io_data=0x%08x", *mask, *bits, ch341_dev->gpio_io_data);
 
     ch341_spi_write_outputs (ch341_dev);
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -1242,6 +1242,7 @@ static void ch341_gpio_remove (struct ch341_device* ch341_dev)
 
 static const struct usb_device_id ch341_usb_table[] = {
     { USB_DEVICE(0x1a86, 0x5512) },
+    { USB_DEVICE(0x1a86, 0x5523) },
     { }
 };
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -531,7 +531,7 @@ static int ch341_spi_write_outputs (struct ch341_device* ch341_dev)
     ch341_dev->out_buf[3] = (data >> 8) & 0xef;
     ch341_dev->out_buf[4] = ((ch341_dev->gpio_mask >> 8) & 0xef) | 0x10;
     ch341_dev->out_buf[5] = (data & 0xff & ~CH341_GPIO_SPI_MASK); // FIXME, set SCK state based on CPOL
-    ch341_dev->out_buf[6] = (ch341_dev->gpio_mask & 0xff & ~CH341_GPIO_SPI_MASK); // Never accidentally drive the SPI signals as GPIOs
+    ch341_dev->out_buf[6] = (ch341_dev->gpio_mask & 0xff & ~CH341_GPIO_SPI_MASK) | SCK_H; // Never accidentally drive the SPI signals as GPIOs
     ch341_dev->out_buf[7] = (data >> 16) & 0x0f;
     ch341_dev->out_buf[8] = 0;
     ch341_dev->out_buf[9] = 0;
@@ -648,11 +648,11 @@ static int ch341_spi_set_cs (struct spi_device *spi, bool active)
         ch341_dev->gpio_io_data |= cs_bits[spi->chip_select];
 
     ch341_dev->out_buf[0]  = CH341_CMD_UIO_STREAM;
-    ch341_dev->out_buf[1]  = CH341_CMD_UIO_STM_DIR | (ch341_dev->gpio_mask & 0xff); // FIXME, set SCK state based on CPOL
+    ch341_dev->out_buf[1]  = CH341_CMD_UIO_STM_DIR | (ch341_dev->gpio_mask & 0xff) | SCK_H; // FIXME, set SCK state based on CPOL
     ch341_dev->out_buf[2]  = CH341_CMD_UIO_STM_OUT | (ch341_dev->gpio_io_data & ch341_dev->gpio_mask & 0xff);
     ch341_dev->out_buf[3]  = CH341_CMD_UIO_STM_END;
 
-    // DEV_DBG(CH341_IF_ADDR, "mask=0x%08x dir=0x%02x val=0x%02x", ch341_dev->gpio_mask, ch341_dev->out_buf[1], ch341_dev->out_buf[2]);
+    DEV_DBG(CH341_IF_ADDR, "mask=0x%x dir=0x%02x val=0x%02x", ch341_dev->gpio_mask, ch341_dev->out_buf[1], ch341_dev->out_buf[2]);
         
     result = ch341_usb_transfer(ch341_dev, 4, 0);
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -690,7 +690,7 @@ static int ch341_spi_transfer_low(struct spi_master *master,
     }
 
     if(t->len == 1) // show bytes transfered if in the common single byte case
-        DEV_DBG (CH341_IF_ADDR, "len=%u, csChange=%d, result=%d, txb=9x%02x, rxb=0x%02x", t->len, t->cs_change, result, tx[0], rx[0]);
+        DEV_DBG (CH341_IF_ADDR, "len=%u, csChange=%d, result=%d, txb=0x%02x, rxb=0x%02x", t->len, t->cs_change, result, tx[0], rx[0]);
     else
         DEV_DBG (CH341_IF_ADDR, "len=%u, csChange=%d, result=%d", t->len, t->cs_change, result);
 
@@ -1108,7 +1108,7 @@ static int ch341_gpio_poll_function (void* argument)
     #ifndef CH341_POLL_WITH_SLEEP
     __set_current_state(TASK_RUNNING);
     #endif
-    
+
     complete(&ch341_dev->gpio_thread_complete);
 
     DEV_DBG (CH341_IF_ADDR, "stop");

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -1183,6 +1183,11 @@ static int ch341_gpio_probe (struct ch341_device* ch341_dev)
     DEV_DBG (CH341_IF_ADDR, "registered GPIOs from %d to %d", 
              gpio->base, gpio->base + gpio->ngpio - 1);
 
+#if 0
+    // @geeksville comment: It seems this code breaks usage on (newer?) kernels.  With kernel 5.8.0
+    // any attempts to set gpio status results in EBUSY error getting returned because it thinks some
+    // other driver (the ch341 driver) already owns this GPIO exclusively.
+
     for (i = 0; i < CH341_GPIO_NUM_PINS; i++)
         // in case the pin is not a CS signal, it is an GPIO pin
         if (ch341_board_config[i].mode != CH341_PIN_MODE_CS)
@@ -1199,6 +1204,7 @@ static int ch341_gpio_probe (struct ch341_device* ch341_dev)
             }
             j++;
         }
+#endif
 
     ch341_dev->gpio_thread = kthread_run (&ch341_gpio_poll_function, ch341_dev, "spi-ch341-usb-poll");
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -537,7 +537,7 @@ static int ch341_spi_write_outputs (struct ch341_device* ch341_dev)
     ch341_dev->out_buf[9] = 0;
     ch341_dev->out_buf[10] = 0;
 
-    DEV_DBG(CH341_IF_ADDR, "mask=0x%08x data=0x%08x", ch341_dev->gpio_mask, data);
+    // DEV_DBG(CH341_IF_ADDR, "mask=0x%08x data=0x%08x", ch341_dev->gpio_mask, data);
     
     result = ch341_usb_transfer(ch341_dev, 11, 0);
 
@@ -1171,8 +1171,7 @@ void ch341_gpio_read_inputs (struct ch341_device* ch341_dev)
     // read current values
     ch341_spi_get_status (ch341_dev);
 
-    if(old_io_data != ch341_dev->gpio_io_data)
-        DEV_DBG (CH341_IF_ADDR, "pins changed 0x%x, oldval 0x%x, newval 0x%x", (old_io_data ^ ch341_dev->gpio_io_data), old_io_data, ch341_dev->gpio_io_data);
+    // if(old_io_data != ch341_dev->gpio_io_data) DEV_DBG (CH341_IF_ADDR, "pins changed 0x%x, oldval 0x%x, newval 0x%x", (old_io_data ^ ch341_dev->gpio_io_data), old_io_data, ch341_dev->gpio_io_data);
 
     for (i = 0; i < ch341_dev->irq_num; i++)
     {

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -63,7 +63,7 @@
   * msecs". This message is thrown if the defined CH341_POLL_PERIOD_MS is
   * shorter than the time required for one reading of the GPIOs. 
   */
-#define CH341_POLL_PERIOD_MS        10    // see above
+#define CH341_POLL_PERIOD_MS        100    // see above
 
 #define CH341_GPIO_NUM_PINS         5     // Number of GPIO pins, DO NOT CHANGE
 
@@ -1130,7 +1130,7 @@ static int ch341_gpio_probe (struct ch341_device* ch341_dev)
 {
     struct gpio_chip *gpio = &ch341_dev->gpio;
     int result;
-    int i, j = 0;
+    // int i, j = 0;
 
     CHECK_PARAM_RET (ch341_dev, -EINVAL);
     
@@ -1415,11 +1415,11 @@ module_usb_driver(ch341_usb_driver);
 
 MODULE_ALIAS("spi:ch341");
 MODULE_AUTHOR("Gunar Schorcht <gunar@schorcht.net>");
-MODULE_DESCRIPTION("spi-ch341-usb driver v1.0.0");
+MODULE_DESCRIPTION("spi-ch341-usb driver v1.0.1");
 MODULE_LICENSE("GPL");
 
 module_param(poll_period, uint, 0644);
-MODULE_PARM_DESC(poll_period, "GPIO polling period in ms (default 10 ms)");
+MODULE_PARM_DESC(poll_period, "GPIO polling period in ms (default 100 ms)");
 
 #endif // LINUX_VERSION_CODE < KERNEL_VERSION(3,10,0)
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -530,8 +530,8 @@ static int ch341_spi_write_outputs (struct ch341_device* ch341_dev)
     ch341_dev->out_buf[2] = 0x1f; // (ch341_dev->gpio_mask & 0xff & ~CH341_GPIO_SPI_MASK) | SCK_H; // 0x1f; // FIXME?
     ch341_dev->out_buf[3] = (data >> 8) & 0xef;
     ch341_dev->out_buf[4] = ((ch341_dev->gpio_mask >> 8) & 0xef) | 0x10;
-    ch341_dev->out_buf[5] = (data & 0xff & ~CH341_GPIO_SPI_MASK); // FIXME, set SCK state based on CPOL
-    ch341_dev->out_buf[6] = (ch341_dev->gpio_mask & 0xff & ~CH341_GPIO_SPI_MASK) | SCK_H; // Never accidentally drive the SPI signals as GPIOs
+    ch341_dev->out_buf[5] = (data & 0xff & ~CH341_GPIO_SPI_MASK) | CH341_MOSI_MASK; // FIXME, set SCK state based on CPOL
+    ch341_dev->out_buf[6] = (ch341_dev->gpio_mask & 0xff & ~CH341_GPIO_SPI_MASK) | SCK_H | CH341_MOSI_MASK; // Never accidentally drive the SPI signals as GPIOs
     ch341_dev->out_buf[7] = (data >> 16) & 0x0f;
     ch341_dev->out_buf[8] = 0;
     ch341_dev->out_buf[9] = 0;
@@ -648,11 +648,11 @@ static int ch341_spi_set_cs (struct spi_device *spi, bool active)
         ch341_dev->gpio_io_data |= cs_bits[spi->chip_select];
 
     ch341_dev->out_buf[0]  = CH341_CMD_UIO_STREAM;
-    ch341_dev->out_buf[1]  = CH341_CMD_UIO_STM_DIR | (ch341_dev->gpio_mask & 0xff) | SCK_H; // FIXME, set SCK state based on CPOL
-    ch341_dev->out_buf[2]  = CH341_CMD_UIO_STM_OUT | (ch341_dev->gpio_io_data & ch341_dev->gpio_mask & 0xff);
+    ch341_dev->out_buf[1]  = CH341_CMD_UIO_STM_DIR | (ch341_dev->gpio_mask & 0xff) | SCK_H | CH341_MOSI_MASK; // FIXME, set SCK state based on CPOL
+    ch341_dev->out_buf[2]  = CH341_CMD_UIO_STM_OUT | (ch341_dev->gpio_io_data & ch341_dev->gpio_mask & 0xff) | CH341_MOSI_MASK;
     ch341_dev->out_buf[3]  = CH341_CMD_UIO_STM_END;
 
-    DEV_DBG(CH341_IF_ADDR, "mask=0x%x dir=0x%02x val=0x%02x", ch341_dev->gpio_mask, ch341_dev->out_buf[1], ch341_dev->out_buf[2]);
+    // DEV_DBG(CH341_IF_ADDR, "mask=0x%x dir=0x%02x val=0x%02x", ch341_dev->gpio_mask, ch341_dev->out_buf[1], ch341_dev->out_buf[2]);
         
     result = ch341_usb_transfer(ch341_dev, 4, 0);
 

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -823,14 +823,18 @@ static void ch341_spi_remove (struct ch341_device* ch341_dev)
     
     CHECK_PARAM (ch341_dev);
     
-    for (i = 0; i < ch341_dev->slave_num; i++)
+    // Not needed because spi_unregister_master (spi_unregister_controller) will do this automatically
+    /* for (i = 0; i < ch341_dev->slave_num; i++)
         if (ch341_dev->slaves[i])
             spi_unregister_device (ch341_dev->slaves[i]);
+    */
 
     if (ch341_dev->master)
     {
         spi_unregister_master (ch341_dev->master);
-        spi_master_put (ch341_dev->master);
+
+        // based on inspection of existing spi drivers in the kernel, this seems unnecessary (and possibly harmful)
+        // spi_master_put (ch341_dev->master);
     }
 
     return;

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -567,7 +567,8 @@ static int ch341_spi_transfer_one(struct spi_master *master,
         result = ch341_usb_transfer(ch341_dev, t->len + 1, t->len);
 
         // deactivate cs
-        ch341_spi_set_cs (spi, false);
+        if (t->cs_change)
+            ch341_spi_set_cs (spi, false);
 
         // fill input data with input buffer, controller delivers lsb first
         if (result >= 0 && rx)
@@ -620,7 +621,11 @@ static int ch341_spi_probe (struct ch341_device* ch341_dev)
     ch341_dev->master->num_chipselect = CH341_SPI_MAX_NUM_DEVICES;
     ch341_dev->master->mode_bits = SPI_MODE_3 | SPI_LSB_FIRST;
     ch341_dev->master->flags = SPI_MASTER_MUST_RX | SPI_MASTER_MUST_TX;
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5,0,0)
+    ch341_dev->master->bits_per_word_mask = SPI_BIT_MASK(8);
+#else
     ch341_dev->master->bits_per_word_mask = SPI_BPW_MASK(8);
+#endif
     ch341_dev->master->transfer_one = ch341_spi_transfer_one;
     ch341_dev->master->max_speed_hz = CH341_SPI_MAX_FREQ;
     ch341_dev->master->min_speed_hz = CH341_SPI_MIN_FREQ;

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -564,7 +564,8 @@ static int ch341_spi_transfer_one(struct spi_master *master,
             ch341_dev->out_buf[i+1] = lsb ? tx[i] : ch341_spi_swap_byte(tx[i]);
 
         // transfer output and input data
-        result = ch341_usb_transfer(ch341_dev, t->len + 1, t->len);
+        if(t->len)
+            result = ch341_usb_transfer(ch341_dev, t->len + 1, t->len);
 
         // deactivate cs
         if (t->cs_change)

--- a/spi-ch341-usb.c
+++ b/spi-ch341-usb.c
@@ -159,7 +159,7 @@ struct ch341_pin_config ch341_board_config[] =
     {   14, CH341_PIN_MODE_IN , "autofd" , 0 },
     {   15, CH341_PIN_MODE_IN , "addr"   , 0 },
 
-    {   16, CH341_PIN_MODE_OUT, "reset"  , 0 },
+    {   16, CH341_PIN_MODE_OUT, "ini"  , 0 },
     {   17, CH341_PIN_MODE_OUT, "write"  , 0 },
     {   18, CH341_PIN_MODE_OUT, "scl"    , 0 },
     {   19, CH341_PIN_MODE_OUT, "sda"    , 0 } // Example code says this is GPIO 29 but I think that is a typo (leaving out for now)

--- a/udev/90-ch341-spi.rules
+++ b/udev/90-ch341-spi.rules
@@ -1,0 +1,11 @@
+#CH341 SPI adapter
+
+# the following didn't work
+# SUBSYSTEM=="usb", ATTR{idVendor}=="1a86", ATTR{idProduct}=="5512", MODE="0666", OWNER="<kevinh>"
+# This worked but too heavyhanded
+# SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chown root:gpio /dev/gpiochip* /sys/class/gpio/export /sys/class/gpio/unexport ; chmod 220 /sys/class/gpio/export /sys/class/gpio/unexport'"
+
+SUBSYSTEM=="gpio", KERNEL=="gpiochip*", GROUP="gpio", MODE="0660"
+SUBSYSTEM=="spidev", KERNEL=="spidev*", GROUP="gpio", MODE="0660"
+
+


### PR DESCRIPTION
* Also includes support for more of the GPIOs based on reading the chinese datasheet. 
* @icenowy did reverse engineering of the closed-source Windows driver to find operations needed to read/write these GPIOs
* Based on that work, it is no longer necessary for the user to wire an extra GPIO input to the dedicated IRQ line.  This driver can now read that IRQ state directly.

Alas, I haven't yet packed this up as a nice PR.  Are you still maintaining this project?  If so, I can scrub my changes to collapse commits into something more atomic.